### PR TITLE
Added Snmp Type to string output of variable.

### DIFF
--- a/SharpSnmpLib/Variable.cs
+++ b/SharpSnmpLib/Variable.cs
@@ -159,7 +159,7 @@ namespace Lextm.SharpSnmpLib
         /// <returns></returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "Variable: Id: {0}; Data: {1}", Id, Data);
+            return string.Format(CultureInfo.InvariantCulture, "Variable: Id: {0}; {1}: {2}", Id, Data.TypeCode.ToString(), Data);
         }
     }
 }


### PR DESCRIPTION
When outputting the variable to string (for example, in a MIB Walk), it's helpful to know the type of data that the library interpreted the data as.